### PR TITLE
Bookオブジェクトにkey, permalink_page, metadata, titleを追加

### DIFF
--- a/kindaipy/book.py
+++ b/kindaipy/book.py
@@ -4,6 +4,7 @@ Initalize with permalink
 ユニークなpermalinkを持つ資料のモジュール
 """
 import kindaipy.util as util
+import re
 
 class Book(object):
     """Bookオブジェクトは国会図書館デジタルライブラリーの個別資料を表す.
@@ -15,5 +16,22 @@ class Book(object):
         """permalinkで初期化する."""
         self.permalink = permalink
         self.permalink_page = util.get_permalink_page(permalink)
+        self.metadata = self.get_metadata()
         self.key = util.get_key(permalink)
-        self.title = ''
+        self.title = self.metadata_like('title')
+
+    def get_metadata(self):
+        dts = self.permalink_page.select('dl.detail-metadata-list dt')
+        dds = self.permalink_page.select('dl.detail-metadata-list dd')
+        metadata = {}
+        for i, dt in enumerate(dts):
+            metadata.update({dt.contents[0]:dds[i].contents[0].strip()})
+
+        return metadata
+
+    def metadata_like(self, query):
+        query_regexp = '\(' + query + '\)'
+        for key, value in self.metadata.items():
+            m = re.search(query_regexp ,key)
+            if m != None:
+                return value

--- a/kindaipy/book.py
+++ b/kindaipy/book.py
@@ -14,6 +14,6 @@ class Book(object):
     def __init__(self, permalink):
         """permalinkで初期化する."""
         self.permalink = permalink
-        self.key = ''
         self.permalink_page = util.get_permalink_page(permalink)
+        self.key = util.get_key(permalink)
         self.title = ''

--- a/kindaipy/tests/test_book.py
+++ b/kindaipy/tests/test_book.py
@@ -32,7 +32,6 @@ class TestBook(unittest.TestCase):
         """資料の題名となるtitle属性をもつこと."""
         self.assertTrue(hasattr(self.book, 'title'))
 
-    @unittest.skip("Not implemented.")
     def test_book_got_title_content(self):
         """資料のtitleをもつこと.スクレイピングで取得する."""
         self.assertEqual(self.book.title, '正義の叫')
@@ -44,6 +43,15 @@ class TestBook(unittest.TestCase):
     def test_book_has_permalink_page_as_bs_object(self):
         """permalink_pageはBeautifulSoupオブジェクトとしてもつこと."""
         self.assertIsInstance(self.book.permalink_page, BeautifulSoup)
+
+    def test_get_metadata(self):
+        self.assertIsInstance(self.book.metadata, dict)
+
+    def test_book_has_metadata(self):
+        self.assertTrue(hasattr(self.book, 'metadata'))
+
+    def test_lookup_from_metadata_from_query(self):
+        self.assertEqual(self.book.metadata_like('title'), '正義の叫')
 
 
 if __name__ == '__main__':

--- a/kindaipy/tests/test_book.py
+++ b/kindaipy/tests/test_book.py
@@ -24,7 +24,6 @@ class TestBook(unittest.TestCase):
         """資料keyを属性としてもつこと."""
         self.assertTrue(hasattr(self.book, 'key'))
 
-    @unittest.skip("Not implemented.")
     def test_book_got_key_content(self):
         """keyはURL最後の番号であること."""
         self.assertEqual(self.book.key, '922693')

--- a/kindaipy/tests/test_util.py
+++ b/kindaipy/tests/test_util.py
@@ -1,4 +1,5 @@
 """Tests for Util module."""
+from bs4 import BeautifulSoup
 from collections import OrderedDict
 import kindaipy.util as util
 import unittest
@@ -18,6 +19,15 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(encoded_params,
                          ('itemId=info%3Andljp%2Fpid%2F922693&'
                           'contentNo=5&outputScale=1'))
+
+    def test_get_permalink_page(self):
+        url = "https://www.google.co.jp/"
+        self.assertIsInstance(util.get_permalink_page(url), BeautifulSoup)
+
+    def test_get_key(self):
+        url = 'http://kindai.ndl.go.jp/info:ndljp/pid/922693'
+        expect_key = '922693'
+        self.assertEqual(util.get_key(url), expect_key)
 
 
 if __name__ == '__main__':

--- a/kindaipy/tests/urls.py
+++ b/kindaipy/tests/urls.py
@@ -1,0 +1,23 @@
+support_urlrs = [
+'http://kindai.ndl.go.jp/info:ndljp/pid/922693', # 正義熱血社出版部 正義の叫
+# 言語
+'http://dl.ndl.go.jp/info:ndljp/pid/2938229',  # 山田美妙 日本大辞書 全 六版
+'http://dl.ndl.go.jp/info:ndljp/pid/862876',   # 落合直文 ことばの泉
+'http://dl.ndl.go.jp/info:ndljp/pid/863017',   # 金沢庄三郎 辞林
+'http://dl.ndl.go.jp/info:ndljp/pid/992954',   # 大槻文彦 編　言海 : 日本辞書. 第1-4冊
+'http://dl.ndl.go.jp/info:ndljp/pid/1265336',  # 大槻文彦 著 大言海. 第3巻
+'http://dl.ndl.go.jp/info:ndljp/pid/1114203',  # 平凡社編 大辞典 volume: 第23巻
+'http://dl.ndl.go.jp/info:ndljp/pid/992501',   #　物集高見 纂　日本大辞林
+'http://dl.ndl.go.jp/info:ndljp/pid/1873360',  # 平凡社編 大辞典 第七卷
+# 民俗
+'http://dl.ndl.go.jp/info:ndljp/pid/969095',   # 物集高見 著 広文庫. 第1冊
+'http://dl.ndl.go.jp/info:ndljp/pid/969114',   # 物集高見 著 広文庫. 広文庫. 第20冊
+# War
+'http://dl.ndl.go.jp/info:ndljp/pid/1718962',  # 久米元一 著[他] 西住戦車長 : 昭和の軍神
+]
+
+nonsupport_urls = [
+# No jpeg spreads
+'http://dl.ndl.go.jp/info:ndljp/pid/6006431', # pdf document
+'http://dl.ndl.go.jp/info:ndljp/pid/2964146', # Index page of Kanpo
+]

--- a/kindaipy/util.py
+++ b/kindaipy/util.py
@@ -3,6 +3,7 @@
 URLの文字列処理などを実装する.
 """
 from bs4 import BeautifulSoup
+import re
 import requests
 from urllib.parse import urlencode
 
@@ -18,3 +19,7 @@ def get_permalink_page(url):
     """Get webpage with bs4."""
     r = requests.get(url)
     return BeautifulSoup(r.text)
+
+def get_key(url):
+    m = re.search("\d+$", url)
+    return m.group(0)

--- a/kindaipy/util.py
+++ b/kindaipy/util.py
@@ -18,7 +18,7 @@ def expand_params(params):
 def get_permalink_page(url):
     """Get webpage with bs4."""
     r = requests.get(url)
-    return BeautifulSoup(r.text)
+    return BeautifulSoup(r.text, "html.parser")
 
 def get_key(url):
     m = re.search("\d+$", url)


### PR DESCRIPTION
permalink_pageはBeautifulSoupのオブジェクトでこれからスクレイピングすると色々な情報がとれます。
metadataはNDLで詳細情報レコードとして列挙されているものの辞書です。
レコードはほぼ不定形なので、取り出し方に注意を要します。
metadataから取り出したものとしてtitleを実装しました。

以上の何れも、本来取得時に例外処理が必要ですよね???????????
がんばりましょう。