### PR TITLE
Bookオブジェクトに全ページ分のSpreadのarrayであるspreadsを追加した

### DIFF
--- a/kindaipy/book.py
+++ b/kindaipy/book.py
@@ -3,6 +3,7 @@
 Initalize with permalink
 ユニークなpermalinkを持つ資料のモジュール
 """
+from kindaipy.spread import Spread
 import kindaipy.util as util
 import re
 
@@ -14,13 +15,16 @@ class Book(object):
 
     def __init__(self, permalink):
         """permalinkで初期化する."""
-        self.permalink = permalink
-        self.permalink_page = util.get_permalink_page(permalink)
-        self.metadata = self.get_metadata()
-        self.key = util.get_key(permalink)
-        self.title = self.metadata_like('title')
-        self.total_spread = self.get_total_spread()
-        self.spreads = []
+        self.permalink =      permalink
+        self.permalink_page = self.get_permalink_page()
+        self.metadata =       self.get_metadata()
+        self.key =            self.get_key()
+        self.title =          self.get_title()
+        self.total_spread =   self.get_total_spread()
+        self.spreads =        self.get_spreads()
+
+    def get_permalink_page(self):
+        return util.get_permalink_page(self.permalink)
 
     def get_metadata(self):
         dts = self.permalink_page.select('dl.detail-metadata-list dt')
@@ -31,6 +35,16 @@ class Book(object):
 
         return metadata
 
+    def get_key(self):
+        return util.get_key(self.permalink)
+
+    def get_title(self):
+        return self.metadata_like('title')
+
+    def get_total_spread(self):
+        page_menu = self.permalink_page.select('#sel-content-no option')
+        return len(page_menu)
+
     def metadata_like(self, query):
         query_regexp = '\(' + query + '\)'
         for key, value in self.metadata.items():
@@ -38,6 +52,12 @@ class Book(object):
             if m != None:
                 return value
 
-    def get_total_spread(self):
-        page_menu = self.permalink_page.select('#sel-content-no option')
-        return len(page_menu)
+    def get_spreads(self):
+        spreads = []
+        for i in enumerate(range(self.total_spread), start=1):
+            spreads.append(Spread(self, i[0]))
+
+        return spreads
+
+    def spread_at(self, spread_number):
+        pass

--- a/kindaipy/book.py
+++ b/kindaipy/book.py
@@ -19,6 +19,8 @@ class Book(object):
         self.metadata = self.get_metadata()
         self.key = util.get_key(permalink)
         self.title = self.metadata_like('title')
+        self.total_spread = self.get_total_spread()
+        self.spreads = []
 
     def get_metadata(self):
         dts = self.permalink_page.select('dl.detail-metadata-list dt')
@@ -35,3 +37,7 @@ class Book(object):
             m = re.search(query_regexp ,key)
             if m != None:
                 return value
+
+    def get_total_spread(self):
+        page_menu = self.permalink_page.select('#sel-content-no option')
+        return len(page_menu)

--- a/kindaipy/spread.py
+++ b/kindaipy/spread.py
@@ -11,10 +11,11 @@ class Spread(object):
 
     def __init__(self, book, spread_number):
         """Bookのインスタンスとページ番号で初期化する."""
-        self.book = book
+        self.book =          book
         self.spread_number = spread_number
+        self.image_url =     self.get_image_url()
 
-    def image_url(self) -> str:
+    def get_image_url(self) -> str:
         """資料keyとページNoをパラメーターに画像のURLを作成する."""
         params = OrderedDict([
             ('itemId',      'info:ndljp/pid/{0}'.format(str(self.book.key))),

--- a/kindaipy/tests/test_book.py
+++ b/kindaipy/tests/test_book.py
@@ -53,6 +53,15 @@ class TestBook(unittest.TestCase):
     def test_lookup_from_metadata_from_query(self):
         self.assertEqual(self.book.metadata_like('title'), '正義の叫')
 
+    def test_book_has_total_spread(self):
+        self.assertTrue(hasattr(self.book, 'total_spread'))
+
+    def test_book_has_number_of_total_spread(self):
+        self.assertEqual(self.book.total_spread, 20)
+
+    def test_book_has_spreads(self):
+        self.assertTrue(hasattr(self.book, 'spreads'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/kindaipy/tests/test_book.py
+++ b/kindaipy/tests/test_book.py
@@ -62,6 +62,18 @@ class TestBook(unittest.TestCase):
     def test_book_has_spreads(self):
         self.assertTrue(hasattr(self.book, 'spreads'))
 
+    def test_book_has_correct_number_of_spreads(self):
+        self.assertEqual(len(self.book.spreads), 20)
+
+    def test_book_has_spreads_with_image_url(self):
+        self.assertEqual(self.book.spreads[0].image_url,
+                         ('http://dl.ndl.go.jp/view/jpegOutput?'
+                          'itemId=info%3Andljp%2Fpid%2F922693'
+                          '&contentNo=1&outputScale=1'))
+
+    def test_book_has_spread_at(self):
+        self.assertTrue(hasattr(self.book, 'spread_at'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/kindaipy/tests/test_spread.py
+++ b/kindaipy/tests/test_spread.py
@@ -9,7 +9,7 @@ class TestSpread(unittest.TestCase):
 
     def setUp(self):
         """Bookのインスタンスとページ番号で初期化する."""
-        self.book = Book('http://kindai.ndl.go.jp/info:ndljp/pid/922693')
+        self.book = Book('http://dl.ndl.go.jp/info:ndljp/pid/922693')
         self.book.key = '922693'
         self.spread_number = '5'
         self.spread = Spread(self.book, self.spread_number)
@@ -22,7 +22,7 @@ class TestSpread(unittest.TestCase):
         """bookのpermalinkを読めること."""
         self.assertEqual(
             self.spread.book.permalink,
-            'http://kindai.ndl.go.jp/info:ndljp/pid/922693')
+            'http://dl.ndl.go.jp/info:ndljp/pid/922693')
 
     @unittest.skip("Not implemented.")
     def test_spread_uri(self):
@@ -32,7 +32,7 @@ class TestSpread(unittest.TestCase):
 
     def test_spread_image_uri(self):
         """資料画像ダウンロードのための正しいURLが得られること."""
-        self.assertEqual(self.spread.image_url(),
+        self.assertEqual(self.spread.image_url,
                          ('http://dl.ndl.go.jp/view/jpegOutput?'
                           'itemId=info%3Andljp%2Fpid%2F922693'
                           '&contentNo=5&outputScale=1'))


### PR DESCRIPTION
Spreadはjpegファイルダウンロード用のURLを持っているので、下のようにBookにNDLのpermalinkを与えると全ページの画像urlリストが取得できるようになった。

```
from kindaipy.book import Book
permalink = 'http://dl.ndl.go.jp/info:ndljp/pid/1772897'
book = Book(permalink)
for spread in book.spreads:
    print(spread.image_url)
```